### PR TITLE
Add UVLFs

### DIFF
--- a/zeus21/UVLFs.py
+++ b/zeus21/UVLFs.py
@@ -1,0 +1,121 @@
+"""
+
+Compute UVLFs given our SFR and HMF models.
+
+Author: Julian B. Muñoz
+UT Austin - June 2023
+
+"""
+
+from . import cosmology
+from .xrays import Xray_class, sigma_HI, sigma_HeI
+from . import constants
+from .sfrd import SFR
+
+import numpy as np
+from scipy.special import erf
+
+
+
+
+
+
+def MUV_of_SFR(SFRtab, kappaUV):
+    'returns MUV, uses SFR. Dust added later in loglike.'
+    #convert SFR to MUVs
+    LUVtab = SFRtab/kappaUV
+    MUVtab = 51.63 - 2.5 * np.log10(LUVtab) #AB magnitude 
+    return MUVtab
+
+
+#and combine to get UVLF:
+def UVLF_binned(Astro_Parameters,Cosmo_Parameters,HMF_interpolator, zcenter, zwidth, MUVcenters, MUVwidths, DUST_FLAG=True, RETURNBIAS = False):
+    'Binned UVLF in units of 1/Mpc^3/mag, for bins at <zcenter> with a Gaussian width zwidth, centered at MUV centers with tophat width MUVwidths. z width only in HMF since that varies the most rapidly. If flag RETURNBIAS set to true it returns number-avgd bias instead of UVLF, still have to divide by UVLF'
+    
+    if(constants.NZ_TOINT>1):
+        DZ_TOINT = np.linspace(-np.sqrt(constants.NZ_TOINT/3.),np.sqrt(constants.NZ_TOINT/3.),constants.NZ_TOINT) #in sigmas around zcenter
+    else:
+        DZ_TOINT = np.array([0.0])
+    WEIGHTS_TOINT = np.exp(-DZ_TOINT**2/2.)/np.sum(np.exp(-DZ_TOINT**2/2.)) #assumed Gaussian in z, fair
+
+
+
+    
+    SFRlist = SFR(Astro_Parameters,Cosmo_Parameters,HMF_interpolator,zcenter)
+    sigmaUV = Astro_Parameters.sigmaUV
+  
+    if (constants.FLAG_RENORMALIZE_LUV == True): #lower the LUV (or SFR) to recover the true avg, not log-avg
+        SFRlist/= np.exp((np.log(10)/2.5*sigmaUV)**2/2.0)
+        
+    MUVbarlist = MUV_of_SFR(SFRlist, Astro_Parameters._kappaUV) #avg for each Mh
+    MUVbarlist = np.fmin(MUVbarlist,constants._MAGMAX)
+    
+    
+
+    if(RETURNBIAS==True): # weight by bias
+        biasM = np.array([bias_Tinker(Cosmo_Parameters, HMF_interpolator.sigma_int(HMF_interpolator.Mhtab,zcenter+dz*zwidth)) for dz in DZ_TOINT])
+    else: # do not weight by bias
+        biasM = np.ones_like(WEIGHTS_TOINT)
+ 
+        
+    HMFtab = np.array([HMF_interpolator.HMF_int(HMF_interpolator.Mhtab,zcenter+dz*zwidth) for dz in DZ_TOINT])
+    HMFcurr = np.sum(WEIGHTS_TOINT * HMFtab.T * biasM.T,axis=1)
+
+    #cannot directly 'dust' the theory since the properties of the IRX-beta relation are calibrated on observed MUV. Recursion instead: 
+    currMUV = MUVbarlist 
+    if(DUST_FLAG==True):
+        currMUV2 = np.ones_like(currMUV)
+        while(np.sum(np.abs((currMUV2-currMUV)/currMUV)) > 0.02):
+            currMUV = MUVbarlist + AUV(Astro_Parameters,zcenter,currMUV) 
+            currMUV2 = currMUV
+           
+    
+    MUVcuthi = MUVcenters +  MUVwidths/2.
+    MUVcutlo = MUVcenters -  MUVwidths/2.
+    
+    xhi = np.subtract.outer(MUVcuthi , currMUV)/(np.sqrt(2) * sigmaUV)
+    xlo = np.subtract.outer(MUVcutlo, currMUV )/(np.sqrt(2) * sigmaUV)
+    weights = (erf(xhi) - erf(xlo)).T/(2.0 * MUVwidths)
+    
+    UVLF_filtered = np.trapz(weights.T * HMFcurr, HMF_interpolator.Mhtab, axis=-1)
+       
+    return UVLF_filtered
+
+
+
+
+
+#####Here the dust attenuation
+def AUV(Astro_Parameters, z, MUV, HIGH_Z_DUST = True, _zmaxdata=8.0):
+    'Average attenuation A as a function of OBSERVED z and magnitude. If using on theory iterate until convergence. HIGH_Z_DUST is whether to do dust at higher z than 0 or set to 0. Fix at \beta(z=8) result if so'
+    
+    betacurr = beta(z,MUV)
+    
+    C0, C1 = Astro_Parameters.C0dust, Astro_Parameters.C1dust   
+    
+    sigmabeta = 0.34 #from Bouwens 2014
+    
+    Auv = C0 + 0.2*np.log(10)*sigmabeta**2 * C1**2 + C1 * betacurr
+    Auv=Auv.T
+    if not (HIGH_Z_DUST):
+        Auv*=np.heaviside(_zmaxdata - z,0.5)
+    Auv=Auv.T
+    return np.fmax(Auv, 0.0)
+
+def beta(z, MUV):
+    'Color as a function of redshift and mag, interpolated from Bouwens 2013-14 data.'
+
+    zdatbeta = [2.5,3.8,5.0,5.9,7.0,8.0]
+    betaMUVatM0 = [-1.7,-1.85,-1.91,-2.00,-2.05,-2.13]
+    dbeta_dMUV = [-0.20,-0.11,-0.14,-0.20,-0.20,-0.15]
+
+    _MUV0 = -19.5
+    _c = -2.33
+
+    betaM0 = np.interp(z, zdatbeta, betaMUVatM0, left=betaMUVatM0[0], right=betaMUVatM0[-1])
+    dbetaM0 = (MUV - _MUV0).T * np.interp(z, zdatbeta, dbeta_dMUV, left=dbeta_dMUV[0], right=dbeta_dMUV[-1]) 
+    
+    sol1 = (betaM0-_c) * np.exp(dbetaM0/(betaM0-_c))+_c #for MUV > MUV0
+    sol2 = dbetaM0 + betaM0 #for MUV < MUV0
+    
+    return sol1.T * np.heaviside(MUV - _MUV0, 0.5) + sol2.T * np.heaviside(_MUV0 - MUV, 0.5)

--- a/zeus21/UVLFs.py
+++ b/zeus21/UVLFs.py
@@ -11,6 +11,7 @@ from . import cosmology
 from .xrays import Xray_class, sigma_HI, sigma_HeI
 from . import constants
 from .sfrd import SFR
+from .cosmology import bias_Tinker
 
 import numpy as np
 from scipy.special import erf

--- a/zeus21/__init__.py
+++ b/zeus21/__init__.py
@@ -4,6 +4,7 @@ from .cosmology import *
 from .correlations import *
 from .sfrd import get_T21_coefficients
 from .xrays import Xray_class
+from .UVLFs import UVLF_binned
 
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning) #to silence unnecessary warning in mcfit

--- a/zeus21/constants.py
+++ b/zeus21/constants.py
@@ -98,3 +98,9 @@ FLAG_DO_BUBBLES = False #whether to do xHI fluctuations (TODO. Global xHI is alw
 #RSD related
 MU_AVG = 0.6 #recovers (1+mu^2)^2 = 1.87, and very close for (1+mu^2) [for cross terms]
 MU_LoS = 1.0 #only fully LoS modes
+
+
+#UVLF related
+_MAGMAX = 10 #max abs magnitude to avoid infs
+FLAG_RENORMALIZE_LUV = False #whether to renormalize the lognormal LUV with sigmaUV to recover <LUV> or otherwise <MUV>. Recommend False.
+NZ_TOINT = 3 #how many zs around <z> with z_rms we use to predict. Only in HMF since the rest do not vary much.

--- a/zeus21/cosmology.py
+++ b/zeus21/cosmology.py
@@ -240,6 +240,34 @@ def T021(Cosmo_Parameters, z):
     return 34 * pow((1+z)/16.,0.5) * (Cosmo_Parameters.omegab/0.022) * pow(Cosmo_Parameters.omegam/0.14,-0.5)
 
 
+#UNUSED bias, just for reference
+def bias_ST(Cosmo_Parameters, sigmaM):
+    # from https://arxiv.org/pdf/1007.4201.pdf Table 1
+    a_ST = Cosmo_Parameters.a_ST
+    p_ST = Cosmo_Parameters.p_ST
+    delta_crit_ST = Cosmo_Parameters.delta_crit_ST
+    nu = delta_crit_ST/sigmaM
+    nutilde = np.sqrt(a_ST) * nu
+    
+    return 1.0 + (nutilde**2 - 1.0 + 2. * p_ST/(1.0 + nutilde**(2. * p_ST) ) )/delta_crit_ST 
+
+def bias_Tinker(Cosmo_Parameters, sigmaM):
+    #from https://arxiv.org/pdf/1001.3162.pdf, Delta=200
+    delta_crit_ST = Cosmo_Parameters.delta_crit_ST
+    nu = delta_crit_ST/sigmaM
+    
+    #Tinker fit
+    _Deltahalo = 200;
+    _yhalo = np.log10(_Deltahalo)
+    _Abias = 1.0 + 0.24 * _yhalo * np.exp(-(4.0/_yhalo)**4.)
+    _abias = 0.44*_yhalo-0.88
+    _Bbias = 0.183
+    _bbias = 1.5
+    _Cbias = 0.019 + 0.107 * _yhalo + 0.19 * np.exp(-(4.0/_yhalo)**4.)
+    _cbias = 2.4
+
+    return 1.0 - _Abias*(nu**_abias/(nu**_abias + delta_crit_ST**_abias)) + _Bbias * nu**_bbias + _Cbias * nu**_cbias
+
 #UNUSED:
 # def interp2Dlinear_only_y(arrayxy, arrayz, x, y):
 #     "2D interpolator where the x axis is assumed to be an array identical to the trained x. That is, an array of 1D linear interpolators. arrayxy is [x,y]. arrayz is result. x is the x input (=arrayxy[0]),  and y the y input. Returns z result (array)"

--- a/zeus21/inputs.py
+++ b/zeus21/inputs.py
@@ -17,7 +17,7 @@ from scipy.interpolate import interp1d
 class Cosmo_Parameters_Input:
     "Class to pass the 6 LCDM parameters as input"
 
-    def __init__(self, omegab= 0.0223828, omegac = 0.1201075, h_fid = 0.67810, As = 2.100549e-09, ns = 0.9660499, tau_fid = 0.05430842, kmax_CLASS = 500., zmax_CLASS = 50., Flag_emulate_21cmfast = False):
+    def __init__(self, omegab= 0.0223828, omegac = 0.1201075, h_fid = 0.67810, As = 2.100549e-09, ns = 0.9660499, tau_fid = 0.05430842, kmax_CLASS = 500., zmax_CLASS = 50.,zmin_CLASS = 5., Flag_emulate_21cmfast = False):
 
         self.omegab = omegab
         self.omegac = omegac
@@ -29,6 +29,7 @@ class Cosmo_Parameters_Input:
         #other params for CLASS
         self.kmax_CLASS = kmax_CLASS
         self.zmax_CLASS = zmax_CLASS
+        self.zmin_CLASS = zmin_CLASS
         #and whether to emulate 21cmFAST
         self.Flag_emulate_21cmfast = Flag_emulate_21cmfast #whether to emulate 21cmFAST in HMF, LyA, and X-ray opacity calculations
 
@@ -49,7 +50,7 @@ class Cosmo_Parameters:
         #other params in the input
         self.kmax_CLASS = CosmoParams_input.kmax_CLASS
         self.zmax_CLASS = CosmoParams_input.zmax_CLASS
-        self.zmin_CLASS = 4.0 #when to start the HMF calcs., not an input strictly
+        self.zmin_CLASS = CosmoParams_input.zmin_CLASS #when to start the HMF calcs., not an input strictly
         self.Flag_emulate_21cmfast = CosmoParams_input.Flag_emulate_21cmfast #whether to emulate 21cmFAST in HMF, LyA, and X-ray opacity calculations
 
         #derived params
@@ -76,8 +77,12 @@ class Cosmo_Parameters:
 
 
         self._ztabinchi = np.linspace(0.0, 100. , 10000) #cheap so do a lot
-        self._chitab = ClassCosmo.z_of_r(self._ztabinchi)[0]
+        # self._chitab = ClassCosmo.z_of_r(self._ztabinchi)[0]
+        # self.zfofRint = interp1d(self._chitab, self._ztabinchi)
+        self._chitab, self._Hztab = ClassCosmo.z_of_r(self._ztabinchi) #chi and dchi/dz
         self.zfofRint = interp1d(self._chitab, self._ztabinchi)
+        self.chiofzint = interp1d(self._ztabinchi,self._chitab)
+        self.Hofzint = interp1d(self._ztabinchi,self._Hztab)
 
         _thermo = ClassCosmo.get_thermodynamics()
         self.Tadiabaticint = interp1d(_thermo['z'], _thermo['Tb [K]'])
@@ -107,7 +112,7 @@ class Cosmo_Parameters:
 
         #HMF-related constants
         if(self.Flag_emulate_21cmfast == False): #standard, best fit ST from Schneider+
-            self.a_ST = 0.85 #0.85 to fit 1805.00021, 0.707 for original ST
+            self.a_ST = 0.707 #OG ST fit, or 0.85 to fit 1805.00021
             self.p_ST = 0.3
             self.Amp_ST = 0.3222
             self.delta_crit_ST = 1.686
@@ -126,7 +131,9 @@ class Cosmo_Parameters:
 class Astro_Parameters:
     "Class to pass the astro parameters as input"
 
-    def __init__(self, Cosmo_Parameters, astromodel = 0, epsstar = 0.1, alphastar = 0.5, betastar = -0.5, Mc = 3e11, fesc10 = 0.1, alphaesc = 0.0, L40_xray = 3.0, E0_xray = 500., alpha_xray = -1.0, Emax_xray_norm=2000, Nalpha_lyA = 9690, Mturn_fixed = None, FLAG_MTURN_SHARP= False, accretion_model = 1):
+    def __init__(self, Cosmo_Parameters, astromodel = 0, epsstar = 0.1, alphastar = 0.5, betastar = -0.5, Mc = 3e11, fesc10 = 0.1, alphaesc = 0.0, \
+                 L40_xray = 3.0, E0_xray = 500., alpha_xray = -1.0, Emax_xray_norm=2000, Nalpha_lyA = 9690, Mturn_fixed = None, FLAG_MTURN_SHARP= False, \
+                    accretion_model = 1, sigmaUV=0.5, C0dust = 4.43, C1dust = 1.99):
 
 
         if(Cosmo_Parameters.Flag_emulate_21cmfast==True and astromodel == 0):
@@ -141,6 +148,7 @@ class Astro_Parameters:
         self.alphastar = alphastar #powerlaw index for lower masses
         self.betastar = betastar #powerlaw index for higher masses, only for model 0
         self.Mc = Mc # mass at which the power law cuts, only for model 0
+        self.sigmaUV = sigmaUV #stochasticity (gaussian rms) in the halo-galaxy connection P(MUV | Mh) - TODO: only used in UVLF not sfrd
 
         if self.astromodel == 0: #GALUMI-like
             self.accretion_model = accretion_model #0 = exponential, 1= EPS #choose the accretion model. Default = EPS
@@ -190,6 +198,10 @@ class Astro_Parameters:
             self.FLAG_MTURN_FIXED = True #whether to fix Mturn or use Matom(z) at each z
             self.Mturn_fixed = Mturn_fixed
             self.FLAG_MTURN_SHARP = FLAG_MTURN_SHARP #whether to do sharp cut at Mturn_fixed or regular exponential cutoff. Only active if FLAG_MTURN_FIXED and turned on by hand.
+
+        #dust parameters for UVLFs:
+        self.C0dust, self.C1dust = C0dust, C1dust #4.43, 1.99 is Meurer99; 4.54, 2.07 is Overzier01
+        self._kappaUV = 1.15e-28 #SFR/LUV, value from Madau+Dickinson14, fully degenerate with epsilon
 
 
 


### PR DESCRIPTION
This adds the functionality of predicting UVLFs with the same parametrization as the 21cm part of the code. They are ultra fast (~1ms), and used in the [2306.09403](https://arxiv.org/abs/2306.09403) paper. It can also predict biases as a function of UV magnitude.