### PR TITLE
Cleaned definition of fH, fHe

### DIFF
--- a/tests/test_cosmology.py
+++ b/tests/test_cosmology.py
@@ -45,7 +45,7 @@ def test_cosmo():
     assert(np.sqrt(CosmoParams.OmegaR) * H0test * (1+zzRad)**2.0 == pytest.approx(HzRadtest, 0.01))
 
 
-    assert(0. <= n_baryon(CosmoParams,0.0) <= 1e-6) #make sure it's reasonable ~1e-7
+    assert(0. <= n_H(CosmoParams,0.0) <= 1e-6) #make sure it's reasonable ~1e-7
 
     assert(2.5<= Tcmb(ClassyCosmo,0.0) <= 3.0) #make sure it's reasonable 2.725 K
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -45,7 +45,8 @@ def test_inputs():
     assert(OmegaToT == pytest.approx(1.0))
 
     #and the fH and fHe fractions
-    assert(CosmoParams.f_He + CosmoParams.f_H == pytest.approx(1.0))
+    assert(CosmoParams.x_He >= 0.)
+    assert(CosmoParams.x_He <= 1.)
 
     #make sure the Rsmoo chosen are reasonable.
     assert(CosmoParams._Rtabsmoo[0] <= 3.0) # the smallest one is small enough

--- a/zeus21/constants.py
+++ b/zeus21/constants.py
@@ -37,7 +37,7 @@ MsunToMpc = MsunToKm * KmToMpc
 Msuntogram = 1.989e33
 GramtoGeV = 1/(6.022e23)
 MsuntoGeV = Msuntogram/GramtoGeV
-mprotoninMsun = 0.94/MsuntoGeV
+mH_GeV = 0.94
 
 c_kms = 299792
 

--- a/zeus21/cosmology.py
+++ b/zeus21/cosmology.py
@@ -62,9 +62,9 @@ def rho_baryon(Cosmo_Parameters,z):
 #\rho_baryon in Msun/Mpc^3 as a function of z
     return Cosmo_Parameters.OmegaB * Cosmo_Parameters.rhocrit * pow(1+z,3.0)
 
-def n_baryon(Cosmo_Parameters, z):
-#density of baryons in 1/cm^3
-    return rho_baryon(Cosmo_Parameters, z) / Cosmo_Parameters.mu_baryon_Msun / (constants.Mpctocm**3.0)
+def n_H(Cosmo_Parameters, z):
+#density of hydrogen nuclei (neutral or ionized) in 1/cm^3
+    return rho_baryon(Cosmo_Parameters, z) *( 1- Cosmo_Parameters.Y_He)/(constants.mH_GeV/constants.MsuntoGeV) / (constants.Mpctocm**3.0)
 
 
 

--- a/zeus21/inputs.py
+++ b/zeus21/inputs.py
@@ -62,10 +62,9 @@ class Cosmo_Parameters:
         self.OmegaB = ClassCosmo.Omega_b()
 
         self.Y_He = ClassCosmo.get_current_derived_parameters(['YHe'])['YHe']
-        self.f_He = self.Y_He/4.0/(1.0 - 3.0/4.0 * self.Y_He) #=nHe/nb
-        self.f_H = (1.0 - self.Y_He)/(1.0 - 3.0/4.0 * self.Y_He) #=nH/nb
-
-        self.mu_baryon = (self.f_H + self.f_He * 4.) * 0.94 #mproton ~ 0.94 GeV
+        self.x_He = self.Y_He/4.0/(1.0 - self.Y_He) #=nHe/nH
+        
+        self.mu_baryon = (1 + self.x_He * 4.)/(1 + self.x_He) * constants.mH_GeV #mproton ~ 0.94 GeV
         self.mu_baryon_Msun = self.mu_baryon/constants.MsuntoGeV
 
 

--- a/zeus21/xrays.py
+++ b/zeus21/xrays.py
@@ -9,7 +9,7 @@ UT Austin and Harvard CfA - January 2023
 
 import numpy as np
 from . import constants
-from .cosmology import n_baryon, HubinvMpc
+from .cosmology import n_H, HubinvMpc
 
 
 class Xray_class:
@@ -17,7 +17,7 @@ class Xray_class:
 
     def __init__(self, Cosmo_Parameters):
 
-        self.atomfractions = np.array([Cosmo_Parameters.f_H,Cosmo_Parameters.f_He]) #faction of baryons in HI and HeI, assumed to just be the avg cosmic
+        self.atomfractions = np.array([1,Cosmo_Parameters.x_He]) #faction of baryons in HI and HeI, assumed to just be the avg cosmic
         self.atomEnIon = np.array([constants.EN_ION_HI, constants.EN_ION_HeI]) #threshold energies for each, in eV
         self.TAUMAX=100. #max optical depth, cut to 0 after to avoid overflows
 
@@ -38,7 +38,7 @@ class Xray_class:
         sigmatot += self.atomfractions[1] * sigma_HeI(Eninttautab)
         sigmatot = sigmatot.T #to broadcast below
 
-        integrand = 1.0/HubinvMpc(Cosmo_Parameters, zinttau)/(1+zinttau) * sigmatot * n_baryon(Cosmo_Parameters, zinttau) * constants.Mpctocm
+        integrand = 1.0/HubinvMpc(Cosmo_Parameters, zinttau)/(1+zinttau) * sigmatot * n_H(Cosmo_Parameters, zinttau) * constants.Mpctocm
         taulist = np.trapz(integrand, zinttau, axis=1)
 
         #OLD: kept for reference only.
@@ -81,7 +81,7 @@ class Xray_class:
         sigmatot = self.atomfractions[0] * sigma_HI(En)
         sigmatot += self.atomfractions[1] * sigma_HeI(En)
 
-        return (1.0/(sigmatot * n_baryon(Cosmo_Parameters,z))/constants.Mpctocm*(1+z) )
+        return (1.0/(sigmatot * n_H(Cosmo_Parameters,z))/constants.Mpctocm*(1+z) )
 
 
 


### PR DESCRIPTION
No changes on any outputs, just redefined H and He fractions so everything depends on nH, since nbaryon is ill defined (is it nH + nHe or nH + 4nHe? depends on whether you count baryons or baryon number...)

Now everything depends on xHe = nHe/nH, and f_H/f_He are removed.